### PR TITLE
ISSUE-15: fixes stream end() being called before write() finished

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-opendkim",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Haraka plugin that uses libopendkim for DKIM",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I changed the `write()` function to simply build an array of buffers that we will construct into a new buffer for processing by `node.opendkim.chunk()` in the `end()` call.  This allows any patching of the message to happen more cleanly in `_build_result()` as well as spares us from the state tracking trouble.

The tradeoff is that it takes more memory than just streaming the message into `node.opendkim`, and prevents of from exiting earlier on detectable errors in the headers (like no signature, or invalid signature).  I'm afraid that the need for `_build_result()` to patch the message is more important than the memory consumed or exiting on early errors.